### PR TITLE
memory: Implement clEnqueueReadBufferRect

### DIFF
--- a/client/exports.def
+++ b/client/exports.def
@@ -19,6 +19,7 @@ clCreateUserEvent
 clEnqueueFillBuffer
 clEnqueueNDRangeKernel
 clEnqueueReadBuffer
+clEnqueueReadBufferRect
 clEnqueueReadImage
 clEnqueueWriteBuffer
 clEnqueueWriteImage

--- a/client/icd.cpp
+++ b/client/icd.cpp
@@ -105,7 +105,7 @@ KHRicdVendorDispatch RemoteCL::Client::OCLDispatchTable =
 	nullptr, //clSetMemObjectDestructorCallback,
 	clCreateUserEvent,
 	clSetUserEventStatus,
-	nullptr, //clEnqueueReadBufferRect,
+	clEnqueueReadBufferRect,
 	nullptr, //clEnqueueWriteBufferRect,
 	nullptr, //clEnqueueCopyBufferRect,
 	nullptr, //clCreateSubDevicesEXT,

--- a/common/packets/commands.h
+++ b/common/packets/commands.h
@@ -73,7 +73,25 @@ struct BufferRW final : public Packet
 	bool mBlock;
 };
 
+template<PacketType Type>
+struct BufferRectRW final : public Packet
+{
+	BufferRectRW() noexcept : Packet(Type) {}
+
+	IDType mBufferID;
+	IDType mQueueID;
+	std::array<uint32_t, 3> mBufferOrigin;
+	std::array<uint32_t, 3> mHostOrigin;
+	std::array<uint32_t, 3> mRegion;
+	uint32_t mBufferRowPitch, mBufferSlicePitch;
+	uint32_t mHostRowPitch, mHostSlicePitch;
+	bool mWantEvent = false;
+	bool mExpectEventList = false;
+	bool mBlock;
+};
+
 using ReadBuffer = BufferRW<PacketType::ReadBuffer>;
+using ReadBufferRect = BufferRectRW<PacketType::ReadBufferRect>;
 using WriteBuffer = BufferRW<PacketType::WriteBuffer>;
 
 struct FillBuffer final : public Packet
@@ -183,6 +201,44 @@ SocketStream& operator >>(SocketStream& i, BufferRW<Type>& E)
 	i >> E.mQueueID;
 	i >> E.mSize;
 	i >> E.mOffset;
+	i >> E.mWantEvent;
+	i >> E.mExpectEventList;
+	i >> E.mBlock;
+
+	return i;
+}
+
+template<PacketType Type>
+SocketStream& operator <<(SocketStream& o, const BufferRectRW<Type>& E)
+{
+	o << E.mBufferID;
+	o << E.mQueueID;
+	o << E.mBufferOrigin;
+	o << E.mHostOrigin;
+	o << E.mRegion;
+	o << E.mBufferRowPitch;
+	o << E.mBufferSlicePitch;
+	o << E.mHostRowPitch;
+	o << E.mHostSlicePitch;
+	o << E.mWantEvent;
+	o << E.mExpectEventList;
+	o << E.mBlock;
+
+	return o;
+}
+
+template<PacketType Type>
+SocketStream& operator >>(SocketStream& i, BufferRectRW<Type>& E)
+{
+	i >> E.mBufferID;
+	i >> E.mQueueID;
+	i >> E.mBufferOrigin;
+	i >> E.mHostOrigin;
+	i >> E.mRegion;
+	i >> E.mBufferRowPitch;
+	i >> E.mBufferSlicePitch;
+	i >> E.mHostRowPitch;
+	i >> E.mHostSlicePitch;
 	i >> E.mWantEvent;
 	i >> E.mExpectEventList;
 	i >> E.mBlock;

--- a/common/packets/packet.h
+++ b/common/packets/packet.h
@@ -75,6 +75,7 @@ enum class PacketType : uint8_t
 	CreateBuffer,
 	CreateSubBuffer,
 	ReadBuffer,
+	ReadBufferRect,
 	WriteBuffer,
 	FillBuffer,
 	GetMemObjInfo,

--- a/server/instance.h
+++ b/server/instance.h
@@ -78,6 +78,7 @@ private:
 	void createBuffer();
 	void createSubBuffer();
 	void readBuffer();
+	void readBufferRect();
 	void writeBuffer();
 	void fillBuffer();
 


### PR DESCRIPTION
Enables initial OpenCV support.
If this function is not exported, OpenCV will fail to load the CL
library handle [1].

[1] https://github.com/opencv/opencv/blob/master/modules/core/src/opencl/runtime/opencl_core.cpp

Signed-off-by: Christopher N. Hesse <christopher.hesse@aptiv.com>