### PR TITLE
event: Implement clSetEventCallback

### DIFF
--- a/client/eventchannel.h
+++ b/client/eventchannel.h
@@ -1,0 +1,54 @@
+// This file is part of RemoteCL.
+
+// RemoteCL is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// RemoteCL is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public License
+// along with RemoteCL.  If not, see <https://www.gnu.org/licenses/>.
+
+#if !defined(REMOTECL_CLIENT_EVENTCHANNEL_H)
+#define REMOTECL_CLIENT_EVENTCHANNEL_H
+
+#include "CL/cl.h"
+
+#include <cassert>
+#include <memory>
+
+namespace RemoteCL
+{
+namespace Client
+{
+
+typedef void (CL_CALLBACK *CL_EVENT_CB) (cl_event event,
+                                         cl_int event_command_exec_status,
+                                         void *user_data);
+
+static uint32_t CallbackID = 1;
+
+struct CLEventCallback
+{
+	explicit CLEventCallback(CL_EVENT_CB cb) noexcept : ID(CallbackID), callback(cb) {
+		assert(ID > 0);
+		CallbackID++;
+	}
+
+	// unique callback ID
+	uint32_t ID;
+
+	cl_event event;
+	cl_int callbackType;
+	CL_EVENT_CB callback;
+	void* userData;
+};
+
+}
+}
+
+#endif

--- a/client/exports.def
+++ b/client/exports.def
@@ -56,6 +56,7 @@ clRetainEvent
 clRetainKernel
 clRetainMemObject
 clRetainProgram
+clSetEventCallback
 clSetKernelArg
 clSetUserEventStatus
 clWaitForEvents

--- a/client/icd.cpp
+++ b/client/icd.cpp
@@ -100,7 +100,7 @@ KHRicdVendorDispatch RemoteCL::Client::OCLDispatchTable =
 	nullptr, //clCreateFromD3D10Texture3DKHR,
 	nullptr, //clEnqueueAcquireD3D10ObjectsKHR,
 	nullptr, //clEnqueueReleaseD3D10ObjectsKHR,
-	nullptr, //clSetEventCallback,
+	clSetEventCallback,
 	clCreateSubBuffer,
 	nullptr, //clSetMemObjectDestructorCallback,
 	clCreateUserEvent,

--- a/common/packets/event.h
+++ b/common/packets/event.h
@@ -25,11 +25,45 @@
 
 namespace RemoteCL
 {
+template<PacketType Type>
+struct EventCallback final : public Packet
+{
+	EventCallback() noexcept : Packet(Type) {}
+
+	// unique callback ID
+	uint32_t mID;
+
+	IDType mEventID;
+	int32_t mCallbackType;
+};
+
 using CreateUserEvent = SimplePacket<PacketType::CreateUserEvent, IDType>;
 using SetUserEventStatus = IDTypePair<PacketType::SetUserEventStatus, uint32_t>;
 using GetEventInfo = IDParamPair<PacketType::GetEventInfo>;
 using GetEventProfilingInfo = IDParamPair<PacketType::GetEventProfilingInfo>;
+using SetEventCallback = EventCallback<PacketType::SetEventCallback>;
+using FireEventCallback = SimplePacket<PacketType::FireEventCallback, uint32_t>;
 using WaitForEvents = SignalPacket<PacketType::WaitEvents>;
+
+template<PacketType Type>
+inline SocketStream& operator <<(SocketStream& o, const EventCallback<Type>& E)
+{
+	o << E.mID;
+	o << E.mEventID;
+	o << E.mCallbackType;
+
+	return o;
+}
+
+template<PacketType Type>
+inline SocketStream& operator >>(SocketStream& i, EventCallback<Type>& E)
+{
+	i >> E.mID;
+	i >> E.mEventID;
+	i >> E.mCallbackType;
+
+	return i;
+}
 }
 
 #endif

--- a/common/packets/packet.h
+++ b/common/packets/packet.h
@@ -94,7 +94,11 @@ enum class PacketType : uint8_t
 	SetUserEventStatus,
 	GetEventInfo,
 	GetEventProfilingInfo,
+	SetEventCallback,
 	WaitEvents,
+
+	// Event backchannel.
+	FireEventCallback,
 
 	// Platform functions.
 	GetPlatformInfo,

--- a/common/packetstream.h
+++ b/common/packetstream.h
@@ -74,6 +74,8 @@ public:
 
 	void flush() { mStream.flush(); }
 
+	void shutdown() { mStream.shutdown(); }
+
 private:
 	/// The underlying buffer for the socket.
 	SocketStream mStream;

--- a/common/socket.cpp
+++ b/common/socket.cpp
@@ -186,3 +186,15 @@ void RemoteCL::Socket::close() noexcept
 #endif
 	closesocket(mSocket);
 }
+
+void RemoteCL::Socket::shutdown() noexcept
+{
+	assert(mSocket != InvalidSocket);
+	int how;
+#if defined(WIN32)
+	how = SD_BOTH
+#else
+	how = SHUT_RDWR;
+#endif
+	::shutdown(mSocket, how);
+}

--- a/common/socket.h
+++ b/common/socket.h
@@ -72,6 +72,8 @@ public:
 	Socket accept();
 	/// Closes this socket.
 	void close() noexcept;
+	/// Performs a socket shutdown.
+	void shutdown() noexcept;
 
 	/// Send this data burst (blocing).
 	void send(const void* data, std::size_t size);

--- a/common/socketstream.h
+++ b/common/socketstream.h
@@ -42,6 +42,9 @@ public:
 	/// Flushes the writes.
 	void flush() { if (mWriteOffset) { flushWriteBuffer(); } }
 
+	/// Shut down the stream, no more reads/writes are possible.
+	void shutdown() { mSocket.shutdown(); }
+
 	/// How many characters available for non-blocking read.
 	std::size_t available() const noexcept
 	{

--- a/server/instance.h
+++ b/server/instance.h
@@ -16,7 +16,11 @@
 #if !defined(REMOTECL_SERVER_INSTANCE_H)
 #define REMOTECL_SERVER_INSTANCE_H
 
+#include <functional>
+#include <list>
 #include <vector>
+
+#include "CL/cl.h"
 
 #include "idtype.h"
 #include "socket.h"
@@ -29,7 +33,7 @@ namespace Server
 class ServerInstance
 {
 public:
-	ServerInstance(Socket socket);
+	ServerInstance(Socket commandSocket, Socket eventSocket);
 
 	void run();
 
@@ -91,8 +95,19 @@ private:
 	void getEventInfo();
 	void getEventProfilingInfo();
 	void setUserEventStatus();
+	void setEventCallback();
 
 	PacketStream mStream;
+	PacketStream mEventStream;
+
+	struct EventCallback {
+		EventCallback(uint32_t id, std::function<void(uint32_t id)> cb) noexcept : ID(id), func(cb) {}
+
+		uint32_t ID;
+		std::function<void(uint32_t id)> func;
+	};
+
+	std::list<EventCallback> mEventCallbacks;
 
 	/// Retrieves or assigns an ID for this object.
 	template<typename T>


### PR DESCRIPTION
Required for OpenCV support.

This patch opens a second TCP connection which then works as event
backchannel and packets are expected to be sent by the server and
received by the client.

Signed-off-by: Christopher N. Hesse <christopher.hesse@aptiv.com>